### PR TITLE
Censoring functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 sf6vid
+samples

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Censor player information in a Street Fighter 6 game play video.
 - [Install](#install)
   - [Prerequisites / Dependencies](#prerequisites--dependencies)
 - [Uninstall](#uninstall)
+- [Contributors](#contributors)
 
 ![](screenshot.png)
 
@@ -28,3 +29,8 @@ This tool uses [ffmpeg](https://ffmpeg.org/) on your system so the `ffmpeg` and 
 Just remove the binary from wherever you installed it.
 
 If you installed it with go, you can do `go uninstall sf6vid`.
+
+
+## Contributors
+
+Built by me for my [Twitch streams (techygrrrl)](https://www.twitch.tv/techygrrrl) with ffmpeg-related help from [TheIdOfAlan](https://www.twitch.tv/theidofalan) and [Kodder](https://www.twitch.tv/kodder).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Censor player information in a Street Fighter 6 game play video.
 
 - [Install](#install)
+  - [Prerequisites / Dependencies](#prerequisites--dependencies)
 - [Uninstall](#uninstall)
 
 ![](screenshot.png)
@@ -15,6 +16,11 @@ Download the release for your operating system from the [releases page](https://
 If you use Go and would like to install it with `go install` you can do the following:
 
     go install github.com/techygrrrl/sf6vid@latest
+
+
+### Prerequisites / Dependencies
+
+This tool uses [ffmpeg](https://ffmpeg.org/) on your system so the `ffmpeg` and `ffprobe` commands must be available.
 
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -1,42 +1,7 @@
 # sf6vid
 
-Censor player information in a Street Fighter 6 game play video.
+Censor player information from your Street Fighter 6 game play videos.
 
-- [Install](#install)
-  - [Prerequisites / Dependencies](#prerequisites--dependencies)
-- [Uninstall](#uninstall)
-- [Contributors](#contributors)
+For installation and usage instructions, see the [wiki](https://github.com/techygrrrl/sf6vid/wiki).
 
 ![](screenshot.png)
-
-
-## Install
-
-Download the release for your operating system from the [releases page](https://github.com/techygrrrl/sf6vid/releases). You can put this somewhere on your path, e.g. in macOS and Linux, you can put it in `/usr/local/bin` or `/usr/bin`.
-
-If you use Go and would like to install it with `go install` you can do the following:
-
-    go install github.com/techygrrrl/sf6vid@latest
-
-
-### Prerequisites / Dependencies
-
-This tool uses [ffmpeg](https://ffmpeg.org/) on your system so the `ffmpeg` and `ffprobe` commands must be available.
-
-
-## Uninstall
-
-Just remove the binary from wherever you installed it.
-
-If you installed it with `go install`, you can find the binary by opening your Go path and deleting the binary.
-
-    open $GOPATH
-
-You can also delete the binary directly from the Go path:
-
-    rm $GOPATH/bin/sf6vid
-
-
-## Contributors
-
-Built by me for my [Twitch streams (techygrrrl)](https://www.twitch.tv/techygrrrl) with ffmpeg-related help from [TheIdOfAlan](https://www.twitch.tv/theidofalan) and [Kodder](https://www.twitch.tv/kodder).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ This tool uses [ffmpeg](https://ffmpeg.org/) on your system so the `ffmpeg` and 
 
 Just remove the binary from wherever you installed it.
 
-If you installed it with go, you can do `go uninstall sf6vid`.
+If you installed it with `go install`, you can find the binary by opening your Go path and deleting the binary.
+
+    open $GOPATH
+
+You can also delete the binary directly from the Go path:
+
+    rm $GOPATH/bin/sf6vid
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# sf6vid
+
+Censor player information in a Street Fighter 6 game play video.
+
+- [Install](#install)
+- [Uninstall](#uninstall)
+
+![](screenshot.png)
+
+
+## Install
+
+Download the release for your operating system from the [releases page](https://github.com/techygrrrl/sf6vid/releases). You can put this somewhere on your path, e.g. in macOS and Linux, you can put it in `/usr/local/bin` or `/usr/bin`.
+
+If you use Go and would like to install it with `go install` you can do the following:
+
+    go install github.com/techygrrrl/sf6vid@latest
+
+
+## Uninstall
+
+Just remove the binary from wherever you installed it.
+
+If you installed it with go, you can do `go uninstall sf6vid`.

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -54,7 +54,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("video resolution: %s", inputVideoResolution)
+	fmt.Printf("video resolution: %v", inputVideoResolution)
 
 	censorBoxes := []video_utils.CensorBox{
 		video_utils.FixedSizeCensorBox{

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/techygrrrl/sf6vid/video_math"
+	"github.com/techygrrrl/sf6vid/video_utils"
 )
 
 var doP1 bool
@@ -47,24 +47,24 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// TODO: replace this with call to ffprobe
-	inputVideoResolution := video_math.CreateVideoResolution("Video", 1920, 1080)
+	inputVideoResolution := video_utils.CreateVideoResolution("Video", 1920, 1080)
 
-	censorBoxes := []video_math.CensorBox{
-		video_math.HardcodedCensorBox{
+	censorBoxes := []video_utils.CensorBox{
+		video_utils.HardcodedCensorBox{
 			Name:   "Title",
 			Width:  250,
 			Height: 50,
 			X:      300,
 			Y:      8,
 		}.ToCensorBox(inputVideoResolution),
-		video_math.HardcodedCensorBox{
+		video_utils.HardcodedCensorBox{
 			Name:   "Rank and Club",
 			Width:  190,
 			Height: 115,
 			X:      16,
 			Y:      105,
 		}.ToCensorBox(inputVideoResolution),
-		video_math.HardcodedCensorBox{
+		video_utils.HardcodedCensorBox{
 			Name:   "Username",
 			Width:  345,
 			Height: 40,
@@ -81,7 +81,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	if doP1 {
 		fmt.Println("should censor player 1: ")
 		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(inputVideoResolution, video_math.Player1)
+			output, err := box.CropFilterOutput(inputVideoResolution, video_utils.Player1)
 
 			if err != nil {
 				log.Fatal(err)
@@ -97,7 +97,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		fmt.Println("should censor player 2: ")
 
 		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(inputVideoResolution, video_math.Player2)
+			output, err := box.CropFilterOutput(inputVideoResolution, video_utils.Player2)
 
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -61,7 +61,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// We use this to calculate the percentage-based censor boxes
-	controlVideoResolution := video_utils.CreateVideoResolution("control", 1920, 1080)
+	controlVideoResolution := video_utils.CreateVideoResolution(1920, 1080)
 
 	inputVideoResolution, err := video_utils.GetVideoResolution(inputPath)
 	if err != nil {

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 	"github.com/techygrrrl/sf6vid/video_utils"
@@ -42,8 +43,15 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	fmt.Println("censor called")
 
 	// Validation
-	if !doP2 && !doP1 {
-		log.Fatalf("must specify flags either --p1 or --p2 (or both)")
+	var playerSide video_utils.PlayerSide = -1
+	if doP1 == doP2 {
+		log.Fatalf("must specify only one of --p1 or --p2")
+	}
+	if doP1 {
+		playerSide = video_utils.Player1
+	}
+	if doP2 {
+		playerSide = video_utils.Player2
 	}
 
 	// We use this to calculate the percentage-based censor boxes
@@ -56,6 +64,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("video resolution: %v", inputVideoResolution)
 
+	// TODO: build this slice based on the p1 and p2 flags
 	censorBoxes := []video_utils.CensorBox{
 		video_utils.FixedSizeCensorBox{
 			Name:   "Title",
@@ -84,36 +93,75 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		fmt.Println(box.PrettyJson())
 	}
 	fmt.Println("-------------------------")
+
+	// TODO: dynamic blur setting
+	blurSetting := video_utils.BlurSetting(4)
+
+	chainLinks := make([]video_utils.ChainLink, len(censorBoxes))
+	for i, box := range censorBoxes {
+		chainLink := video_utils.CreateChainLink(box, blurSetting)
+		chainLinks[i] = chainLink
+	}
+
+	chainAssembler := video_utils.CreateChainAssembler(chainLinks)
+
+	filterComplexChain, err := chainAssembler.AssembleChain(*inputVideoResolution, playerSide)
+
+	censorCommandOutput, err := exec.Command(
+		"ffmpeg",
+		"-i", inputPath,
+		"-filter_complex", filterComplexChain,
+		"-map", "[base]",
+		//"-map \"[base]\"",
+		"-y",
+		outputPath,
+	).Output()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("succes???? \n\n\n%s", string(censorCommandOutput))
+
+	//ffmpeg \
+	//-i samples/sample-720x480.mp4 \
+	//-filter_complex "[0:v]crop=94:23:113:4,boxblur=4[blur1];[0:v][blur1]overlay=113:4[blurred1];[0:v]crop=72:52:6:47,boxblur=4[blur2];[blurred1][blur2]overlay=6:47[blurred2];[0:v]crop=130:18:77:48,boxblur=4[blur3];[blurred2][blur3]overlay=77:48" \
+	//-y \
+	//samples/blurred.mp4
+
+	//currentIdx := 1
 	//filterComplex := ""
 
-	if doP1 {
-		fmt.Println("should censor player 1: ")
-		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player1)
-
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// TODO: remove - this is just for debugging
-			fmt.Printf("Box: %s \nFilter output: %s \n\n", box.Name, output)
-		}
-		fmt.Println("-------------------------")
-	}
-
-	if doP2 {
-		fmt.Println("should censor player 2: ")
-
-		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player2)
-
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// TODO: remove - this is just for debugging
-			fmt.Printf("Box: %s \nFilter output: %s \n\n", box.Name, output)
-		}
-		fmt.Println("-------------------------")
-	}
+	// Censor player 1
+	//if doP1 {
+	//	fmt.Println("should censor player 1: ")
+	//	for _, box := range censorBoxes {
+	//		output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player1)
+	//
+	//		if err != nil {
+	//			log.Fatal(err)
+	//		}
+	//
+	//		// TODO: remove - this is just for debugging
+	//		fmt.Printf("Box: %s \nFilter output: %s \n\n", box.Name, output)
+	//	}
+	//	fmt.Println("-------------------------")
+	//}
+	//
+	//// Censor player 2
+	//if doP2 {
+	//	fmt.Println("should censor player 2: ")
+	//
+	//	for _, box := range censorBoxes {
+	//		output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player2)
+	//
+	//		if err != nil {
+	//			log.Fatal(err)
+	//		}
+	//
+	//		// TODO: remove - this is just for debugging
+	//		fmt.Printf("Box: %s \nFilter output: %s \n\n", box.Name, output)
+	//	}
+	//	fmt.Println("-------------------------")
+	//}
 }

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -46,42 +46,50 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("must specify flags either --p1 or --p2 (or both)")
 	}
 
-	// TODO: replace this with call to ffprobe
-	inputVideoResolution := video_utils.CreateVideoResolution("Video", 1920, 1080)
+	// We use this to calculate the percentage-based censor boxes
+	controlVideoResolution := video_utils.CreateVideoResolution("control", 1920, 1080)
+
+	inputVideoResolution, err := video_utils.GetVideoResolution(inputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("video resolution: %s", inputVideoResolution)
 
 	censorBoxes := []video_utils.CensorBox{
-		video_utils.HardcodedCensorBox{
+		video_utils.FixedSizeCensorBox{
 			Name:   "Title",
 			Width:  250,
 			Height: 50,
 			X:      300,
 			Y:      8,
-		}.ToCensorBox(inputVideoResolution),
-		video_utils.HardcodedCensorBox{
+		}.ToCensorBox(controlVideoResolution),
+		video_utils.FixedSizeCensorBox{
 			Name:   "Rank and Club",
 			Width:  190,
 			Height: 115,
 			X:      16,
 			Y:      105,
-		}.ToCensorBox(inputVideoResolution),
-		video_utils.HardcodedCensorBox{
+		}.ToCensorBox(controlVideoResolution),
+		video_utils.FixedSizeCensorBox{
 			Name:   "Username",
 			Width:  345,
 			Height: 40,
 			X:      205,
 			Y:      106,
-		}.ToCensorBox(inputVideoResolution),
+		}.ToCensorBox(controlVideoResolution),
 	}
-	// TODO: remove - this is just for debugging
+
 	for _, box := range censorBoxes {
 		fmt.Println(box.PrettyJson())
 	}
 	fmt.Println("-------------------------")
+	//filterComplex := ""
 
 	if doP1 {
 		fmt.Println("should censor player 1: ")
 		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(inputVideoResolution, video_utils.Player1)
+			output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player1)
 
 			if err != nil {
 				log.Fatal(err)
@@ -97,7 +105,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		fmt.Println("should censor player 2: ")
 
 		for _, box := range censorBoxes {
-			output, err := box.CropFilterOutput(inputVideoResolution, video_utils.Player2)
+			output, err := box.CropFilterOutput(*inputVideoResolution, video_utils.Player2)
 
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/file_utils/file_utils_darwin.go
+++ b/file_utils/file_utils_darwin.go
@@ -1,6 +1,8 @@
 package file_utils
 
-import "os/exec"
+import (
+	"os/exec"
+)
 
 func OpenFile(filepath string) error {
 	_, err := exec.Command("open", filepath).Output()

--- a/file_utils/file_utils_darwin.go
+++ b/file_utils/file_utils_darwin.go
@@ -1,0 +1,8 @@
+package file_utils
+
+import "os/exec"
+
+func OpenFile(filepath string) error {
+	_, err := exec.Command("open", filepath).Output()
+	return err
+}

--- a/file_utils/file_utils_linux.go
+++ b/file_utils/file_utils_linux.go
@@ -1,0 +1,5 @@
+package file_utils
+
+func OpenFile(filepath string) error {
+	return "command unsupported: https://github.com/techygrrrl/sf6vid/issues/4"
+}

--- a/file_utils/file_utils_linux.go
+++ b/file_utils/file_utils_linux.go
@@ -1,5 +1,7 @@
 package file_utils
 
+import "fmt"
+
 func OpenFile(filepath string) error {
-	return fmt.Error("command unsupported: https://github.com/techygrrrl/sf6vid/issues/4")
+	return fmt.Errorf("command unsupported: https://github.com/techygrrrl/sf6vid/issues/4")
 }

--- a/file_utils/file_utils_linux.go
+++ b/file_utils/file_utils_linux.go
@@ -1,5 +1,5 @@
 package file_utils
 
 func OpenFile(filepath string) error {
-	return "command unsupported: https://github.com/techygrrrl/sf6vid/issues/4"
+	return fmt.Error("command unsupported: https://github.com/techygrrrl/sf6vid/issues/4")
 }

--- a/file_utils/file_utils_windows.go
+++ b/file_utils/file_utils_windows.go
@@ -3,5 +3,5 @@ package file_utils
 import "fmt"
 
 func OpenFile(filepath string) error {
-	return fmt.Error("command unsupported: https://github.com/techygrrrl/sf6vid/issues/3")
+	return fmt.Errorf("command unsupported: https://github.com/techygrrrl/sf6vid/issues/3")
 }

--- a/file_utils/file_utils_windows.go
+++ b/file_utils/file_utils_windows.go
@@ -1,0 +1,5 @@
+package file_utils
+
+func OpenFile(filepath string) error {
+	return "command unsupported: https://github.com/techygrrrl/sf6vid/issues/3"
+}

--- a/file_utils/file_utils_windows.go
+++ b/file_utils/file_utils_windows.go
@@ -1,5 +1,7 @@
 package file_utils
 
+import "fmt"
+
 func OpenFile(filepath string) error {
-	return "command unsupported: https://github.com/techygrrrl/sf6vid/issues/3"
+	return fmt.Error("command unsupported: https://github.com/techygrrrl/sf6vid/issues/3")
 }

--- a/video_utils/ffmpeg.go
+++ b/video_utils/ffmpeg.go
@@ -23,14 +23,9 @@ func CreateChainAssembler(chainLinks []ChainLink) ChainAssembler {
 }
 
 func (c ChainAssembler) AssembleChain(v VideoResolution, side PlayerSide) (string, error) {
-	//output := []string{
-	//	"[0:v]copy[base]",
-	//}
-
 	output := make([]string, len(c.ChainLinks)+1)
 	output[0] = "[0:v]copy[base]"
 
-	//output := "[0:v]copy[base];"
 	for i, chainLink := range c.ChainLinks {
 		currentIndex := i + 1
 
@@ -40,7 +35,6 @@ func (c ChainAssembler) AssembleChain(v VideoResolution, side PlayerSide) (strin
 		}
 
 		output[currentIndex] = chainLinkOutput
-		//output = append(output, chainLinkOutput)
 	}
 
 	stringOutput := strings.Join(output, ";")
@@ -69,22 +63,6 @@ func (c ChainLink) AssembleChainLink(currentIndex int, v VideoResolution, side P
 		currentIndex,
 		overlayOutput,
 	)
-	//CMD="$CMD[0:v]crop=94:23:0:0,boxblur=4[blur0];"
-	//CMD="$CMD[base][blur0]overlay=113:4[base];"
-
-	//output := fmt.Sprintf(
-	//	"[0:v]%s,%s[blur%d];[%s][blur%d]%s[blurred%d]",
-	//	cropFilterOutput,
-	//	c.BlurSetting.FilterOutput(),
-	//	currentIndex,
-	//	c.OverlaySource,
-	//	currentIndex,
-	//	overlayOutput,
-	//	currentIndex,
-	//)
 
 	return output, nil
 }
-
-//[0:v]crop=94:23:113:4,boxblur=0[blur1]; DONE
-//[0:v][blur1]overlay=113:4[blurred1]; TODO

--- a/video_utils/ffmpeg.go
+++ b/video_utils/ffmpeg.go
@@ -1,0 +1,90 @@
+package video_utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ChainLink struct {
+	CensorBox   CensorBox
+	BlurSetting BlurSetting
+}
+
+func CreateChainLink(censorBox CensorBox, blurSetting BlurSetting) ChainLink {
+	return ChainLink{censorBox, blurSetting}
+}
+
+type ChainAssembler struct {
+	ChainLinks []ChainLink
+}
+
+func CreateChainAssembler(chainLinks []ChainLink) ChainAssembler {
+	return ChainAssembler{chainLinks}
+}
+
+func (c ChainAssembler) AssembleChain(v VideoResolution, side PlayerSide) (string, error) {
+	//output := []string{
+	//	"[0:v]copy[base]",
+	//}
+
+	output := make([]string, len(c.ChainLinks)+1)
+	output[0] = "[0:v]copy[base]"
+
+	//output := "[0:v]copy[base];"
+	for i, chainLink := range c.ChainLinks {
+		currentIndex := i + 1
+
+		chainLinkOutput, err := chainLink.AssembleChainLink(currentIndex, v, side)
+		if err != nil {
+			return "", err
+		}
+
+		output[currentIndex] = chainLinkOutput
+		//output = append(output, chainLinkOutput)
+	}
+
+	stringOutput := strings.Join(output, ";")
+
+	return stringOutput, nil
+}
+
+func (c ChainLink) AssembleChainLink(currentIndex int, v VideoResolution, side PlayerSide) (string, error) {
+	cropFilterOutput, err := c.CensorBox.CropFilterOutput(v, side)
+	if err != nil {
+		return "", err
+	}
+
+	overlayOutput, err := c.CensorBox.OverlayOutput(v, side)
+	if err != nil {
+		return "", err
+	}
+
+	blurFilterOutput := c.BlurSetting.FilterOutput()
+
+	output := fmt.Sprintf(
+		"[0:v]%s,%s[blur%d];[base][blur%d]%s[base]",
+		cropFilterOutput,
+		blurFilterOutput,
+		currentIndex,
+		currentIndex,
+		overlayOutput,
+	)
+	//CMD="$CMD[0:v]crop=94:23:0:0,boxblur=4[blur0];"
+	//CMD="$CMD[base][blur0]overlay=113:4[base];"
+
+	//output := fmt.Sprintf(
+	//	"[0:v]%s,%s[blur%d];[%s][blur%d]%s[blurred%d]",
+	//	cropFilterOutput,
+	//	c.BlurSetting.FilterOutput(),
+	//	currentIndex,
+	//	c.OverlaySource,
+	//	currentIndex,
+	//	overlayOutput,
+	//	currentIndex,
+	//)
+
+	return output, nil
+}
+
+//[0:v]crop=94:23:113:4,boxblur=0[blur1]; DONE
+//[0:v][blur1]overlay=113:4[blurred1]; TODO

--- a/video_utils/ffmpeg_test.go
+++ b/video_utils/ffmpeg_test.go
@@ -25,7 +25,7 @@ func TestChainLink_Assemble(t *testing.T) {
 	result, err := subject.AssembleChainLink(currentIndex, bigVideo, side)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "[0:v]crop=251:50:300:8,avgblur=4[blur2];[base][blur2]overlay=300:8[base]", result)
+	assert.Equal(t, "[0:v]crop=251:50:300:8,boxblur=4[blur2];[base][blur2]overlay=300:8[base]", result)
 }
 
 func TestChainAssembler_AssembleChain(t *testing.T) {
@@ -65,5 +65,5 @@ func TestChainAssembler_AssembleChain(t *testing.T) {
 	result, err := subject.AssembleChain(bigVideo, side)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "foo", result)
+	assert.Equal(t, "[0:v]copy[base];[0:v]crop=251:50:300:8,boxblur=4[blur1];[base][blur1]overlay=300:8[base];[0:v]crop=190:115:16:105,boxblur=4[blur2];[base][blur2]overlay=16:105[base];[0:v]crop=345:40:205:106,boxblur=4[blur3];[base][blur3]overlay=205:106[base]", result)
 }

--- a/video_utils/ffmpeg_test.go
+++ b/video_utils/ffmpeg_test.go
@@ -1,0 +1,69 @@
+package video_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainLink_Assemble(t *testing.T) {
+	currentIndex := 2
+	bigVideo := CreateVideoResolution("big", 1920, 1080)
+	side := Player1
+
+	subject := ChainLink{
+		CensorBox: FixedSizeCensorBox{
+			Name:   "Title",
+			Width:  250,
+			Height: 50,
+			X:      300,
+			Y:      8,
+		}.ToCensorBox(bigVideo),
+		BlurSetting: BlurSetting(4),
+	}
+
+	result, err := subject.AssembleChainLink(currentIndex, bigVideo, side)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "[0:v]crop=251:50:300:8,avgblur=4[blur2];[base][blur2]overlay=300:8[base]", result)
+}
+
+func TestChainAssembler_AssembleChain(t *testing.T) {
+	blurSetting := BlurSetting(4)
+	bigVideo := CreateVideoResolution("big", 1920, 1080)
+	side := Player1
+	censorBoxes := []CensorBox{
+		FixedSizeCensorBox{
+			Name:   "Title",
+			Width:  250,
+			Height: 50,
+			X:      300,
+			Y:      8,
+		}.ToCensorBox(bigVideo),
+		FixedSizeCensorBox{
+			Name:   "Rank and Club",
+			Width:  190,
+			Height: 115,
+			X:      16,
+			Y:      105,
+		}.ToCensorBox(bigVideo),
+		FixedSizeCensorBox{
+			Name:   "Username",
+			Width:  345,
+			Height: 40,
+			X:      205,
+			Y:      106,
+		}.ToCensorBox(bigVideo),
+	}
+	chainLinks := make([]ChainLink, len(censorBoxes))
+	for i, box := range censorBoxes {
+		chainLink := CreateChainLink(box, blurSetting)
+		chainLinks[i] = chainLink
+	}
+
+	subject := CreateChainAssembler(chainLinks)
+	result, err := subject.AssembleChain(bigVideo, side)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", result)
+}

--- a/video_utils/ffmpeg_test.go
+++ b/video_utils/ffmpeg_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestChainLink_Assemble(t *testing.T) {
 	currentIndex := 2
-	bigVideo := CreateVideoResolution("big", 1920, 1080)
+	bigVideo := CreateVideoResolution(1920, 1080)
 	side := Player1
 
 	subject := ChainLink{
@@ -30,7 +30,7 @@ func TestChainLink_Assemble(t *testing.T) {
 
 func TestChainAssembler_AssembleChain(t *testing.T) {
 	blurSetting := BlurSetting(4)
-	bigVideo := CreateVideoResolution("big", 1920, 1080)
+	bigVideo := CreateVideoResolution(1920, 1080)
 	side := Player1
 	censorBoxes := []CensorBox{
 		FixedSizeCensorBox{

--- a/video_utils/ffprobe.go
+++ b/video_utils/ffprobe.go
@@ -2,7 +2,6 @@ package video_utils
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -35,12 +34,12 @@ func GetVideoResolution(path string) (*VideoResolution, error) {
 
 	width, err := strconv.Atoi(result[0])
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	height, err := strconv.Atoi(result[1])
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	videoResolution := CreateVideoResolution("", width, height)

--- a/video_utils/ffprobe.go
+++ b/video_utils/ffprobe.go
@@ -1,0 +1,49 @@
+package video_utils
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func GetVideoResolution(path string) (*VideoResolution, error) {
+	// https://superuser.com/a/841379
+	resolutionBytes, err := exec.Command(
+		"ffprobe",
+		"-v", "error", "-select_streams", "v:0", "-show_entries",
+		"stream=width,height", "-of", "csv=s=x:p=0",
+		path,
+	).Output()
+
+	if err != nil {
+		return nil, fmt.Errorf("file not found")
+	}
+
+	// Resulting output is something like this: 1080x720
+	resolutionStr := strings.ReplaceAll(
+		string(resolutionBytes),
+		"\n",
+		"",
+	)
+
+	result := strings.Split(resolutionStr, "x")
+	if len(result) != 2 {
+		return nil, fmt.Errorf("invalid resolutionBytes: %s", resolutionStr)
+	}
+
+	width, err := strconv.Atoi(result[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	height, err := strconv.Atoi(result[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	videoResolution := CreateVideoResolution("", width, height)
+
+	return &videoResolution, nil
+}

--- a/video_utils/ffprobe.go
+++ b/video_utils/ffprobe.go
@@ -42,7 +42,7 @@ func GetVideoResolution(path string) (*VideoResolution, error) {
 		panic(err)
 	}
 
-	videoResolution := CreateVideoResolution("", width, height)
+	videoResolution := CreateVideoResolution(width, height)
 
 	return &videoResolution, nil
 }

--- a/video_utils/ffprobe.go
+++ b/video_utils/ffprobe.go
@@ -30,7 +30,7 @@ func GetVideoResolution(path string) (*VideoResolution, error) {
 
 	result := strings.Split(resolutionStr, "x")
 	if len(result) != 2 {
-		return nil, fmt.Errorf("invalid resolutionBytes: %s", resolutionStr)
+		return nil, fmt.Errorf("invalid resolution: %s", resolutionStr)
 	}
 
 	width, err := strconv.Atoi(result[0])

--- a/video_utils/ffprobe_test.go
+++ b/video_utils/ffprobe_test.go
@@ -1,0 +1,12 @@
+package video_utils
+
+// TODO: Run this locally for testing.
+// You'll need a folder ./samples at the root with a sample video file named accordingly
+//func TestGetVideoResolution(t *testing.T) {
+//	result, err := GetVideoResolution("../samples/sample-1080x720.mp4")
+//
+//	assert.Nil(t, err)
+//
+//	assert.Equal(t, 1080, result.Width())
+//	assert.Equal(t, 720, result.Height())
+//}

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -1,4 +1,4 @@
-package video_math
+package video_utils
 
 import (
 	"encoding/json"
@@ -97,7 +97,7 @@ func (c CensorBox) CropFilterOutput(v VideoResolution, side PlayerSide) (string,
 // region Video
 
 type VideoResolution struct {
-	name   string
+	name   string // todo: consider removing this field
 	width  int
 	height int
 }
@@ -106,6 +106,7 @@ func CreateVideoResolution(name string, width int, height int) VideoResolution {
 	return VideoResolution{name, width, height}
 }
 
+// Name todo: consider removing this field
 func (v VideoResolution) Name() string {
 	return v.name
 }

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -129,18 +129,12 @@ func (c CensorBox) OverlayOutput(v VideoResolution, side PlayerSide) (string, er
 // region Video
 
 type VideoResolution struct {
-	name   string // todo: consider removing this field
 	width  int
 	height int
 }
 
-func CreateVideoResolution(name string, width int, height int) VideoResolution {
-	return VideoResolution{name, width, height}
-}
-
-// Name todo: consider removing this field
-func (v VideoResolution) Name() string {
-	return v.name
+func CreateVideoResolution(width int, height int) VideoResolution {
+	return VideoResolution{width, height}
 }
 
 func (v VideoResolution) Width() int {
@@ -158,12 +152,10 @@ func (v VideoResolution) Height() int {
 type BlurSetting int
 
 func CreateBlurSetting(value int) BlurSetting {
-	// todo: pass the CensorBox here as an argument and get the Math.min value
 	return BlurSetting(value)
 }
 
 func (b BlurSetting) FilterOutput() string {
-	// todo: pass the CensorBox here as an argument and get the Math.min value
 	return fmt.Sprintf("boxblur=%d", b)
 }
 

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -37,8 +37,8 @@ func (c CensorBox) PrettyJson() (string, error) {
 	return string(asJson), nil
 }
 
-// HardcodedCensorBox To assist with calculating a CensorBox when provided a VideoResolution
-type HardcodedCensorBox struct {
+// FixedSizeCensorBox To assist with calculating a CensorBox when provided a VideoResolution
+type FixedSizeCensorBox struct {
 	Name   string
 	Width  int
 	Height int
@@ -46,7 +46,7 @@ type HardcodedCensorBox struct {
 	Y      int
 }
 
-func (box HardcodedCensorBox) ToCensorBox(v VideoResolution) CensorBox {
+func (box FixedSizeCensorBox) ToCensorBox(v VideoResolution) CensorBox {
 	return CensorBox{
 		Name:             box.Name,
 		WidthPercentage:  float64(box.Width) / float64(v.width),

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -164,8 +164,7 @@ func CreateBlurSetting(value int) BlurSetting {
 
 func (b BlurSetting) FilterOutput() string {
 	// todo: pass the CensorBox here as an argument and get the Math.min value
-	return fmt.Sprintf("avgblur=%d", b)
-	//return fmt.Sprintf("boxblur=%d", b)
+	return fmt.Sprintf("boxblur=%d", b)
 }
 
 // endregion Blur settings

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var bigVideo = CreateVideoResolution("Big Video", 1920, 1080)
-var smallVideo = CreateVideoResolution("Small Video", 960, 540)
+var bigVideo = CreateVideoResolution(1920, 1080)
+var smallVideo = CreateVideoResolution(960, 540)
 
 func TestCensorBox_CropFilterOutput_p1(t *testing.T) {
 	// title box
@@ -49,15 +49,13 @@ func TestCensorBox_CropFilterOutput_p2(t *testing.T) {
 }
 
 func TestVideoResolution(t *testing.T) {
-	subject1 := CreateVideoResolution("SD", 720, 480)
+	subject1 := CreateVideoResolution(720, 480)
 
-	assert.Equal(t, "SD", subject1.Name())
 	assert.Equal(t, 720, subject1.Width())
 	assert.Equal(t, 480, subject1.Height())
 
-	subject2 := CreateVideoResolution("beeg", 1920, 1080)
+	subject2 := CreateVideoResolution(1920, 1080)
 
-	assert.Equal(t, "beeg", subject2.Name())
 	assert.Equal(t, 1920, subject2.Width())
 	assert.Equal(t, 1080, subject2.Height())
 }

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -68,7 +68,7 @@ func TestBlurSettings_FilterOutput(t *testing.T) {
 }
 
 func TestHardcodedCensorBox_ToCensorBox(t *testing.T) {
-	title := HardcodedCensorBox{
+	title := FixedSizeCensorBox{
 		Name:   "Title Box",
 		Width:  250,
 		Height: 50,
@@ -93,21 +93,21 @@ func TestHardcodedCensorBox_ToCensorBox(t *testing.T) {
 
 func TestHardcodedCensorBox_ToCensorBox_moreBoxes(t *testing.T) {
 	censorBoxes := []CensorBox{
-		HardcodedCensorBox{
+		FixedSizeCensorBox{
 			Name:   "Title",
 			Width:  250,
 			Height: 50,
 			X:      300,
 			Y:      8,
 		}.ToCensorBox(bigVideo),
-		HardcodedCensorBox{
+		FixedSizeCensorBox{
 			Name:   "Rank and Club",
 			Width:  190,
 			Height: 115,
 			X:      16,
 			Y:      105,
 		}.ToCensorBox(bigVideo),
-		HardcodedCensorBox{
+		FixedSizeCensorBox{
 			Name:   "Username",
 			Width:  345,
 			Height: 40,

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -120,3 +120,18 @@ func TestHardcodedCensorBox_ToCensorBox_moreBoxes(t *testing.T) {
 		fmt.Println(box.PrettyJson())
 	}
 }
+
+func TestCensorBox_OverlayOutput(t *testing.T) {
+	// title box
+	titleCensorBox := CensorBox{
+		Name:             "Title Box",
+		WidthPercentage:  0.130208333333333,
+		HeightPercentage: 0.046296296296296,
+		XPercentage:      0.15625,
+		YPercentage:      0.007407407407407,
+	}
+
+	smallResult, err := titleCensorBox.OverlayOutput(smallVideo, Player2)
+	assert.Nil(t, err)
+	assert.Equal(t, "overlay=685:4", smallResult)
+}

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -63,8 +63,8 @@ func TestVideoResolution(t *testing.T) {
 }
 
 func TestBlurSettings_FilterOutput(t *testing.T) {
-	assert.Equal(t, "avgblur=10", CreateBlurSetting(10).FilterOutput())
-	assert.Equal(t, "avgblur=20", CreateBlurSetting(20).FilterOutput())
+	assert.Equal(t, "boxblur=10", CreateBlurSetting(10).FilterOutput())
+	assert.Equal(t, "boxblur=20", CreateBlurSetting(20).FilterOutput())
 }
 
 func TestHardcodedCensorBox_ToCensorBox(t *testing.T) {

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -1,4 +1,4 @@
-package video_math
+package video_utils
 
 import (
 	"fmt"


### PR DESCRIPTION
User can blur a video with the following command:

```
sf6vid censor -i samples/sample-1080x720.mp4 -o samples/output.mp4 --p1 --open --blur 6
```

- custom blur setting
- blur either player 1 or player 2 side (but not both)
- allow the user to open the file with a flag

More command info:

```
sf6vid censor --help
Censor either the player 1 or player 2 identifying information in the video.
If the output path already exists, it will be replaced.

Usage:
  sf6vid censor [flags]

Flags:
  -b, --blur int        Custom blur value (default 6)
  -h, --help            help for censor
  -i, --input string    Path to input file
      --open            Open the file after running this command
  -o, --output string   Path to output file
      --p1              Censor player 1 side
      --p2              Censor player 2 side
```

<img width="1392" alt="image" src="https://github.com/techygrrrl/sf6vid/assets/88961088/04279db8-5239-4120-a46b-6b6bfe417f66">
