### PR TITLE
Change default filter to pixelize instead of box blur

### DIFF
--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -29,12 +29,17 @@ If the output path already exists, it will be replaced.
 
 func init() {
 	// Command options
+	// player config
 	censorCmd.Flags().BoolVar(&doP1, "p1", false, "Censor player 1 side")
 	censorCmd.Flags().BoolVar(&doP2, "p2", false, "Censor player 2 side")
-	censorCmd.Flags().BoolVar(&openFile, "open", false, "Open the file after running this command")
+
+	// files
 	censorCmd.Flags().StringVarP(&inputPath, "input", "i", "", "Path to input file")
 	censorCmd.Flags().StringVarP(&outputPath, "output", "o", "", "Path to output file")
-	censorCmd.Flags().IntVarP(&blurSetting, "blur", "b", 6, "Custom blur value for the box blur")
+	censorCmd.Flags().BoolVar(&openFile, "open", false, "Open the file after running this command")
+
+	// blur config
+	censorCmd.Flags().IntVar(&blurSetting, "blur", 6, "Custom blur value for when the box blur is used (requires --box-blur flag otherwise this value will be ignored)")
 	censorCmd.Flags().BoolVar(&shouldUseLegacyBlur, "box-blur", false, "Use the box blur filter instead of the new pixelize filter (pixelize requires ffmpeg 6+)")
 
 	err := censorCmd.MarkFlagRequired("input")

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -13,6 +13,7 @@ import (
 var doP1 bool
 var doP2 bool
 var openFile bool
+var shouldUseLegacyBlur bool
 var inputPath string
 var outputPath string
 var blurSetting int
@@ -33,7 +34,8 @@ func init() {
 	censorCmd.Flags().BoolVar(&openFile, "open", false, "Open the file after running this command")
 	censorCmd.Flags().StringVarP(&inputPath, "input", "i", "", "Path to input file")
 	censorCmd.Flags().StringVarP(&outputPath, "output", "o", "", "Path to output file")
-	censorCmd.Flags().IntVarP(&blurSetting, "blur", "b", 6, "Custom blur value")
+	censorCmd.Flags().IntVarP(&blurSetting, "blur", "b", 6, "Custom blur value for the box blur")
+	censorCmd.Flags().BoolVar(&shouldUseLegacyBlur, "box-blur", false, "Use the box blur filter instead of the new pixelize filter (pixelize requires ffmpeg 6+)")
 
 	err := censorCmd.MarkFlagRequired("input")
 	if err != nil {
@@ -94,7 +96,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 
 	chainLinks := make([]video_utils.ChainLink, len(censorBoxes))
 	for i, box := range censorBoxes {
-		chainLink := video_utils.CreateChainLink(box, video_utils.BlurSetting(blurSetting))
+		chainLink := video_utils.CreateChainLink(box, video_utils.CreateBlurSetting(blurSetting, !shouldUseLegacyBlur))
 		chainLinks[i] = chainLink
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:     "sf6vid",
-	Version: "0.1.2",
+	Version: "0.2.0",
 }
 
 func Execute() {

--- a/video_utils/ffmpeg.go
+++ b/video_utils/ffmpeg.go
@@ -7,10 +7,10 @@ import (
 
 type ChainLink struct {
 	CensorBox   CensorBox
-	BlurSetting BlurSetting
+	BlurSetting BlurSettings
 }
 
-func CreateChainLink(censorBox CensorBox, blurSetting BlurSetting) ChainLink {
+func CreateChainLink(censorBox CensorBox, blurSetting BlurSettings) ChainLink {
 	return ChainLink{censorBox, blurSetting}
 }
 

--- a/video_utils/ffmpeg_test.go
+++ b/video_utils/ffmpeg_test.go
@@ -19,7 +19,7 @@ func TestChainLink_Assemble(t *testing.T) {
 			X:      300,
 			Y:      8,
 		}.ToCensorBox(bigVideo),
-		BlurSetting: BlurSetting(4),
+		BlurSetting: CreateBlurSetting(4, false),
 	}
 
 	result, err := subject.AssembleChainLink(currentIndex, bigVideo, side)
@@ -28,8 +28,8 @@ func TestChainLink_Assemble(t *testing.T) {
 	assert.Equal(t, "[0:v]crop=251:50:300:8,boxblur=4[blur2];[base][blur2]overlay=300:8[base]", result)
 }
 
-func TestChainAssembler_AssembleChain(t *testing.T) {
-	blurSetting := BlurSetting(4)
+func TestChainAssembler_AssembleChain_blur(t *testing.T) {
+	blurSetting := CreateBlurSetting(4, false)
 	bigVideo := CreateVideoResolution(1920, 1080)
 	side := Player1
 	censorBoxes := []CensorBox{
@@ -66,4 +66,44 @@ func TestChainAssembler_AssembleChain(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "[0:v]copy[base];[0:v]crop=251:50:300:8,boxblur=4[blur1];[base][blur1]overlay=300:8[base];[0:v]crop=190:115:16:105,boxblur=4[blur2];[base][blur2]overlay=16:105[base];[0:v]crop=345:40:205:106,boxblur=4[blur3];[base][blur3]overlay=205:106[base];[0:a]acopy", result)
+}
+
+func TestChainAssembler_AssembleChain_pixelize(t *testing.T) {
+	blurSetting := CreateBlurSetting(4, true)
+	bigVideo := CreateVideoResolution(1920, 1080)
+	side := Player1
+	censorBoxes := []CensorBox{
+		FixedSizeCensorBox{
+			Name:   "Title",
+			Width:  250,
+			Height: 50,
+			X:      300,
+			Y:      8,
+		}.ToCensorBox(bigVideo),
+		FixedSizeCensorBox{
+			Name:   "Rank and Club",
+			Width:  190,
+			Height: 115,
+			X:      16,
+			Y:      105,
+		}.ToCensorBox(bigVideo),
+		FixedSizeCensorBox{
+			Name:   "Username",
+			Width:  345,
+			Height: 40,
+			X:      205,
+			Y:      106,
+		}.ToCensorBox(bigVideo),
+	}
+	chainLinks := make([]ChainLink, len(censorBoxes))
+	for i, box := range censorBoxes {
+		chainLink := CreateChainLink(box, blurSetting)
+		chainLinks[i] = chainLink
+	}
+
+	subject := CreateChainAssembler(chainLinks)
+	result, err := subject.AssembleChain(bigVideo, side)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "[0:v]copy[base];[0:v]crop=251:50:300:8,pixelize=16:16:avg[blur1];[base][blur1]overlay=300:8[base];[0:v]crop=190:115:16:105,pixelize=16:16:avg[blur2];[base][blur2]overlay=16:105[base];[0:v]crop=345:40:205:106,pixelize=16:16:avg[blur3];[base][blur3]overlay=205:106[base];[0:a]acopy", result)
 }

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -149,14 +149,21 @@ func (v VideoResolution) Height() int {
 
 // region Blur settings
 
-type BlurSetting int
-
-func CreateBlurSetting(value int) BlurSetting {
-	return BlurSetting(value)
+type BlurSettings struct {
+	BoxBlur  int
+	Pixelize bool
 }
 
-func (b BlurSetting) FilterOutput() string {
-	return fmt.Sprintf("boxblur=%d", b)
+func CreateBlurSetting(value int, pixelize bool) BlurSettings {
+	return BlurSettings{value, pixelize}
+}
+
+func (b BlurSettings) FilterOutput() string {
+	if b.Pixelize {
+		return "pixelize=16:16:avg"
+	}
+
+	return fmt.Sprintf("boxblur=%d", b.BoxBlur)
 }
 
 // endregion Blur settings

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -61,8 +61,8 @@ func TestVideoResolution(t *testing.T) {
 }
 
 func TestBlurSettings_FilterOutput(t *testing.T) {
-	assert.Equal(t, "boxblur=10", CreateBlurSetting(10).FilterOutput())
-	assert.Equal(t, "boxblur=20", CreateBlurSetting(20).FilterOutput())
+	assert.Equal(t, "boxblur=10", CreateBlurSetting(10, false).FilterOutput())
+	assert.Equal(t, "boxblur=20", CreateBlurSetting(20, false).FilterOutput())
 }
 
 func TestHardcodedCensorBox_ToCensorBox(t *testing.T) {


### PR DESCRIPTION
In the screenshot, the first image uses box blur (original). In the bottom image, the filter is the new pixelize filter which is only supported in ffmpeg 6+. 

<img width="1530" alt="Screen Shot 2023-09-16 at 2 46 49 AM" src="https://github.com/techygrrrl/sf6vid/assets/88961088/57c1086b-db9b-46f1-a56f-6fa59b4ab018">

## Breaking changes

Pixelize is now the default because of these changes. Pixelize doesn't look good on WSL (Ubuntu).

To use the original box blur, the flag `--box-blur` will need to be provided. 