### PR TITLE
Size matters: Add command `shrink` and optimize video size output 

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -7,9 +7,11 @@ Usage:
 Available Commands:
   censor      Censor the player information in a video
   help        Help about any command
+  shrink      Shrinks the video frame size by the indicated percentage, and compresses the quality in other ways
   trim        Trim the video for the provided start and/or end times
 
 Flags:
+      --debug     More verbose logging
   -h, --help      help for sf6vid
   -v, --version   version for sf6vid
 
@@ -32,8 +34,11 @@ Flags:
       --blur int         Custom blur value for when the box blur is used (requires --box-blur flag otherwise this value will be ignored) (default 6)
       --box-blur         Use the box blur filter instead of the new pixelize filter (pixelize requires ffmpeg 6+)
       --start duration   Optional start time for trimming the video
-      --end duration     Optional start time for trimming the video
+      --end duration     Optional end time for trimming the video
   -h, --help             help for censor
+
+Global Flags:
+      --debug   More verbose logging
 ```
 ### trim
 ```
@@ -53,4 +58,7 @@ Flags:
       --start duration   Start time for trimming the video
       --end duration     End time for trimming the video
   -h, --help             help for trim
+
+Global Flags:
+      --debug   More verbose logging
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -7,7 +7,7 @@ Usage:
 Available Commands:
   censor      Censor the player information in a video
   help        Help about any command
-  shrink      Shrinks the video frame size by the indicated percentage, and compresses the quality in other ways
+  shrink      Reduces the size of the video including frame by the indicated percentage, and compresses the quality in other ways
   trim        Trim the video for the provided start and/or end times
 
 Flags:

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/techygrrrl/sf6vid/file_utils"
+	"github.com/techygrrrl/sf6vid/string_utils"
 	"github.com/techygrrrl/sf6vid/video_utils"
 )
 
@@ -178,7 +179,16 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	commandArgs = append(commandArgs, durationArgs...)
 
 	// append the output path
-	commandArgs = append(commandArgs, outputPath)
+	var censoredPlayerString string
+	if doP1 {
+		censoredPlayerString = "p1"
+	} else {
+		censoredPlayerString = "p2"
+	}
+
+	durationSuffix := fmt.Sprintf("censored_%s_%s-%s", censoredPlayerString, startTime.String(), endTime.String())
+	outputPathWithCensoredSuffix := string_utils.AppendStringToFileName(outputPath, durationSuffix)
+	commandArgs = append(commandArgs, outputPathWithCensoredSuffix)
 
 	if flagUseDebug {
 		fmt.Printf("⚙️  Executing command:\n\nffmpeg %s\n\n", strings.Join(commandArgs, " "))
@@ -189,7 +199,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPath)
+	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithCensoredSuffix)
 	fmt.Printf("✅ Censored video was output to: %s\n", fullFilePath)
 
 	if openFile {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagUseDebug bool = false
+
 var rootCmd = &cobra.Command{
 	Use:     "sf6vid",
 	Version: "0.3.0",
@@ -20,4 +22,5 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVar(&flagUseDebug, "debug", false, "More verbose logging")
 }

--- a/cmd/shrink.go
+++ b/cmd/shrink.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/techygrrrl/sf6vid/string_utils"
+	"github.com/techygrrrl/sf6vid/video_utils"
+)
+
+var shrinkCmd = &cobra.Command{
+	Use:   "shrink",
+	Short: "Shrinks the video frame size by the indicated percentage, and compresses the quality in other ways",
+	Long:  `Allows you to specify a percentage by which the video frame will be shrunk.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		inputPath, err := cmd.Flags().GetString("input")
+		if err != nil {
+			panic(err)
+		}
+
+		outputPath, err := cmd.Flags().GetString("output")
+		if err != nil {
+			panic(err)
+		}
+
+		targetPercent, err := cmd.Flags().GetInt("size")
+		if err != nil {
+			panic(err)
+		}
+		if targetPercent <= 0 || targetPercent >= 101 {
+			panic(fmt.Errorf("invalid target percent: %d - `size` must be between 1 and 101", targetPercent))
+		}
+
+		inputVideoResolution, err := video_utils.GetVideoResolution(inputPath)
+		if err != nil {
+			panic(err)
+		}
+
+		scaledResolution := inputVideoResolution.GetScaledResolution(targetPercent)
+		outputPathWithScaledSuffix := string_utils.AppendStringToFileName(outputPath, scaledResolution.String())
+
+		commandArgs := []string{
+			"-i", inputPath,
+
+			// Quality-related. Constant Rate Factor, which lowers the average bit rate, but retains better quality.
+			// Vary the CRF between around 18 and 24 — the lower, the higher the bitrate.
+			// H.265 may use a crf between 24 to 30
+			// See: https://unix.stackexchange.com/a/38380
+
+			// This one is slightly larger but plays in QuickTime
+			// "-b", "800k", "-crf", "28",
+			// This one is slightly smaller but does not play in QuickTime but plays fine in VLC and Discord embeds
+			"-c:v", "libx265", "-crf", "30",
+			"-s", scaledResolution.String(),
+			"-y",
+			outputPathWithScaledSuffix,
+		}
+
+		if flagUseDebug {
+			fmt.Printf("⚙️  Executing command:\n\nffmpeg %s\n\n", strings.Join(commandArgs, " "))
+		}
+		_, err = exec.Command("ffmpeg", commandArgs...).Output()
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("✅ Shrunk video was output to: %s\n", outputPathWithScaledSuffix)
+	},
+}
+
+func init() {
+	shrinkCmd.Flags().SortFlags = false
+
+	shrinkCmd.Flags().StringP("input", "i", "", "Path to input file")
+	shrinkCmd.Flags().StringP("output", "o", "", "Path to output file")
+	shrinkCmd.Flags().IntP("size", "s", 100, "Desired output size of the video percentage, e.g. a video that is 1280x720 will be 640x360 if you specify --size 50")
+
+	rootCmd.AddCommand(shrinkCmd)
+}

--- a/cmd/shrink.go
+++ b/cmd/shrink.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -15,6 +16,11 @@ var shrinkCmd = &cobra.Command{
 	Short: "Shrinks the video frame size by the indicated percentage, and compresses the quality in other ways",
 	Long:  `Allows you to specify a percentage by which the video frame will be shrunk.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+
 		inputPath, err := cmd.Flags().GetString("input")
 		if err != nil {
 			panic(err)
@@ -66,7 +72,8 @@ var shrinkCmd = &cobra.Command{
 			panic(err)
 		}
 
-		fmt.Printf("✅ Shrunk video was output to: %s\n", outputPathWithScaledSuffix)
+		fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithScaledSuffix)
+		fmt.Printf("✅ Shrunk video was output to: %s\n", fullFilePath)
 	},
 }
 

--- a/cmd/trim.go
+++ b/cmd/trim.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/techygrrrl/sf6vid/file_utils"
+	"github.com/techygrrrl/sf6vid/string_utils"
 	"github.com/techygrrrl/sf6vid/video_utils"
 )
 
@@ -96,7 +97,10 @@ func runTrimCmd(cmd *cobra.Command, args []string) {
 	}
 
 	commandArgs = append(commandArgs, durationArgs...)
-	commandArgs = append(commandArgs, outputPath)
+
+	durationSuffix := fmt.Sprintf("trimmed_%s-%s", startTime.String(), endTime.String())
+	outputPathWithTrimmedSuffix := string_utils.AppendStringToFileName(outputPath, durationSuffix)
+	commandArgs = append(commandArgs, outputPathWithTrimmedSuffix)
 
 	if flagUseDebug {
 		fmt.Printf("⚙️  Executing command:\n\nffmpeg %s\n\n", strings.Join(commandArgs, " "))
@@ -107,7 +111,7 @@ func runTrimCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPath)
+	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithTrimmedSuffix)
 	fmt.Printf("✅ Trimmed video was output to: %s\n", fullFilePath)
 
 	if openFile {

--- a/cmd/trim.go
+++ b/cmd/trim.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -87,21 +88,27 @@ func runTrimCmd(cmd *cobra.Command, args []string) {
 	durationArgs := video_utils.FormattedDurationArgsForFFmpeg(startTime, endTime)
 	commandArgs := []string{
 		"-i", inputPath,
+
+		// Quality settings. See shrink
+		"-c:v", "libx265", "-crf", "30",
+
 		"-y",
 	}
 
 	commandArgs = append(commandArgs, durationArgs...)
 	commandArgs = append(commandArgs, outputPath)
 
+	if flagUseDebug {
+		fmt.Printf("⚙️  Executing command:\n\nffmpeg %s\n\n", strings.Join(commandArgs, " "))
+	}
 	_, err = exec.Command("ffmpeg", commandArgs...).Output()
-
 	if err != nil {
 		fmt.Println("💥 could not trim the video")
 		os.Exit(1)
 	}
 
 	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPath)
-	fmt.Printf("✅ Trimmed video should be available at %s\n", fullFilePath)
+	fmt.Printf("✅ Trimmed video was output to: %s\n", fullFilePath)
 
 	if openFile {
 		err = file_utils.OpenFile(fullFilePath)

--- a/string_utils/string_utils.go
+++ b/string_utils/string_utils.go
@@ -1,0 +1,11 @@
+package string_utils
+
+import "regexp"
+
+func AppendStringToFileName(fileName string, stringToAppend string) string {
+	m1 := regexp.MustCompile(`\.([^.]*)$`)
+	fileExtWithDot := m1.FindString(fileName)
+	withSuffix := m1.ReplaceAllString(fileName, "_"+stringToAppend+fileExtWithDot)
+
+	return withSuffix
+}

--- a/string_utils/string_utils_test.go
+++ b/string_utils/string_utils_test.go
@@ -1,0 +1,25 @@
+package string_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendStringToFileName_worksForMp4(t *testing.T) {
+	filename := "out.mp4"
+	stringToAppend := "640x360"
+
+	result := AppendStringToFileName(filename, stringToAppend)
+
+	assert.Equal(t, "out_640x360.mp4", result)
+}
+
+func TestAppendStringToFileName_worksForMov(t *testing.T) {
+	filename := "out.mov"
+	stringToAppend := "640x360"
+
+	result := AppendStringToFileName(filename, stringToAppend)
+
+	assert.Equal(t, "out_640x360.mov", result)
+}

--- a/video_utils/video_math.go
+++ b/video_utils/video_math.go
@@ -145,6 +145,21 @@ func (v VideoResolution) Height() int {
 	return v.height
 }
 
+func (v VideoResolution) String() string {
+	return fmt.Sprintf("%dx%d", v.width, v.height)
+}
+
+func (v VideoResolution) GetScaledResolution(scalePercent int) VideoResolution {
+	sizeDiff := float32(scalePercent) * 0.01
+	targetWidth := float32(v.Width()) * sizeDiff
+	targetHeight := float32(v.Height()) * sizeDiff
+
+	return VideoResolution{
+		width:  int(targetWidth),
+		height: int(targetHeight),
+	}
+}
+
 // endregion Video
 
 // region Blur settings

--- a/video_utils/video_math_test.go
+++ b/video_utils/video_math_test.go
@@ -133,3 +133,19 @@ func TestCensorBox_OverlayOutput(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "overlay=685:4", smallResult)
 }
+
+func TestGetScaledResolution(t *testing.T) {
+	subject := VideoResolution{
+		width:  1280,
+		height: 720,
+	}
+
+	output := subject.GetScaledResolution(50)
+	// Correct values
+	assert.Equal(t, 640, output.width)
+	assert.Equal(t, 360, output.height)
+	// Original struct unchanged
+	assert.Equal(t, 1280, subject.width)
+	assert.Equal(t, 720, subject.height)
+	fmt.Printf("Scaled: %v , Original: %v ", output, subject)
+}


### PR DESCRIPTION
Closes https://github.com/techygrrrl/sf6vid/issues/15

## shrink

Adds shrink which allows the user to shrink the video frame by a percentage, e.g.

```sh
sf6vid shrink -i samples/sample-1080x720.mp4 -o samples/shrunk.mp4 -s 50
```

You'll get:

```
✅ Shrunk video was output to: /path/to/samples/shrunk_540x360.mp4
```

## censor

The censor command now outputs a suffix that indicates which side was censored and the start/end time from the source video:

```sh
sf6vid censor -i samples/sample-1080x720.mp4 -o samples/foo.mp4 --p2 --start 2s --end 9s
```

Result:

```
✅ Censored video was output to: /path/to/samples/foo_censored_p2_2s-9s.mp4
```


## trim

The trim command now outputs that it was trimmed and the start/end time from the source video:

```sh
sf6vid trim -i samples/sample-1080x720.mp4 -o samples/foo.mp4 --start 2s --end 9s
```

Output:

```
✅ Trimmed video was output to: /path/to/samples/foo_trimmed_2s-9s.mp4
```

## General quality settings

Changes the codec to use H.265 which is more optimal re: size. This change was done to all commands.

## --debug

Outputs more verbose logging if you do `--debug` with any command.
