### PR TITLE
Support --open flag on Windows

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -13,6 +13,7 @@ Available Commands:
 Flags:
       --debug     More verbose logging
   -h, --help      help for sf6vid
+      --open      Open the file after running this command
   -v, --version   version for sf6vid
 
 Use "sf6vid [command] --help" for more information about a command.
@@ -30,7 +31,6 @@ Flags:
       --p2               Censor player 2 side
   -i, --input string     Path to input file
   -o, --output string    Path to output file
-      --open             Open the file after running this command
       --blur int         Custom blur value for when the box blur is used (requires --box-blur flag otherwise this value will be ignored) (default 6)
       --box-blur         Use the box blur filter instead of the new pixelize filter (pixelize requires ffmpeg 6+)
       --start duration   Optional start time for trimming the video
@@ -39,6 +39,7 @@ Flags:
 
 Global Flags:
       --debug   More verbose logging
+      --open    Open the file after running this command
 ```
 ### trim
 ```
@@ -54,13 +55,13 @@ Usage:
 Flags:
   -i, --input string     Path to input file
   -o, --output string    Path to output file
-      --open             Open the file after running this command
       --start duration   Start time for trimming the video
       --end duration     End time for trimming the video
   -h, --help             help for trim
 
 Global Flags:
       --debug   More verbose logging
+      --open    Open the file after running this command
 ```
 ### shrink
 ```
@@ -78,4 +79,5 @@ Flags:
 
 Global Flags:
       --debug   More verbose logging
+      --open    Open the file after running this command
 ```

--- a/cmd/censor.go
+++ b/cmd/censor.go
@@ -33,7 +33,6 @@ func init() {
 	// files
 	censorCmd.Flags().StringP("input", "i", "", "Path to input file")
 	censorCmd.Flags().StringP("output", "o", "", "Path to output file")
-	censorCmd.Flags().Bool("open", false, "Open the file after running this command")
 
 	// blur config
 	censorCmd.Flags().Int("blur", 6, "Custom blur value for when the box blur is used (requires --box-blur flag otherwise this value will be ignored)")
@@ -56,11 +55,6 @@ func init() {
 }
 
 func runCensorCmd(cmd *cobra.Command, args []string) {
-	openFile, err := cmd.Flags().GetBool("open")
-	if err != nil {
-		panic(err)
-	}
-
 	doP1, err := cmd.Flags().GetBool("p1")
 	if err != nil {
 		panic(err)
@@ -202,7 +196,7 @@ func runCensorCmd(cmd *cobra.Command, args []string) {
 	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithCensoredSuffix)
 	fmt.Printf("✅ Censored video was output to: %s\n", fullFilePath)
 
-	if openFile {
+	if flagOpen {
 		err = file_utils.OpenFile(fullFilePath)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 )
 
 var flagUseDebug bool = false
+var flagOpen bool = false
 
 var rootCmd = &cobra.Command{
 	Use:     "sf6vid",
@@ -23,4 +24,5 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagUseDebug, "debug", false, "More verbose logging")
+	rootCmd.PersistentFlags().BoolVar(&flagOpen, "open", false, "Open the file after running this command")
 }

--- a/cmd/shrink.go
+++ b/cmd/shrink.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/techygrrrl/sf6vid/file_utils"
 	"github.com/techygrrrl/sf6vid/string_utils"
 	"github.com/techygrrrl/sf6vid/video_utils"
 )
@@ -90,6 +91,10 @@ Uses H.265 encoding to further compress the video.
 
 		fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithScaledSuffix)
 		fmt.Printf("✅ Shrunk video was output to: %s\n", fullFilePath)
+
+		if flagOpen {
+			err = file_utils.OpenFile(fullFilePath)
+		}
 	},
 }
 

--- a/cmd/trim.go
+++ b/cmd/trim.go
@@ -31,7 +31,6 @@ func init() {
 	// files
 	trimCmd.Flags().StringP("input", "i", "", "Path to input file")
 	trimCmd.Flags().StringP("output", "o", "", "Path to output file")
-	trimCmd.Flags().Bool("open", false, "Open the file after running this command")
 
 	// trim config
 	trimCmd.Flags().Duration("start", time.Duration(0), "Start time for trimming the video")
@@ -56,11 +55,6 @@ func runTrimCmd(cmd *cobra.Command, args []string) {
 	}
 
 	outputPath, err := cmd.Flags().GetString("output")
-	if err != nil {
-		panic(err)
-	}
-
-	openFile, err := cmd.Flags().GetBool("open")
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +108,7 @@ func runTrimCmd(cmd *cobra.Command, args []string) {
 	fullFilePath := fmt.Sprintf("%s/%s", cwd, outputPathWithTrimmedSuffix)
 	fmt.Printf("✅ Trimmed video was output to: %s\n", fullFilePath)
 
-	if openFile {
+	if flagOpen {
 		err = file_utils.OpenFile(fullFilePath)
 	}
 }

--- a/file_utils/file_utils_windows.go
+++ b/file_utils/file_utils_windows.go
@@ -1,7 +1,11 @@
 package file_utils
 
-import "fmt"
+import "os/exec"
 
 func OpenFile(filepath string) error {
-	return fmt.Errorf("command unsupported: https://github.com/techygrrrl/sf6vid/issues/3")
+	_, err := exec.Command("PowerShell", "-Command", "Start-Process", filepath).Output()
+	if err != nil {
+		panic(err)
+	}
+	return err
 }


### PR DESCRIPTION
Closes https://github.com/techygrrrl/sf6vid/issues/3

Also makes the open flag a persistent flag to avoid code duplication.

Adds support for `--open` flag in `shrink` command for all supported systems.